### PR TITLE
fix: 앱 실행 즉시 종료 문제 수정 - 테마를 NoActionBar로 변경

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.TextEditor" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.TextEditor" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="colorPrimary">@color/purple_500</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>
         <item name="colorOnPrimary">@android:color/white</item>


### PR DESCRIPTION
DarkActionBar 테마는 윈도우 데코르에서 기본 ActionBar를 제공하는데,
setSupportActionBar()를 함께 호출하면 IllegalStateException이 발생하여 앱이 실행 즉시 종료되는 문제가 발생합니다.

테마 parent를 Theme.MaterialComponents.DayNight.DarkActionBar에서 Theme.MaterialComponents.DayNight.NoActionBar로 변경하여 수정합니다.

https://claude.ai/code/session_01MmV9QuEzbYjc2jw3Rozrx7