### PR TITLE
fix: 앱 실행 즉시 종료 문제 수정

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,6 @@ name: Build APK
 on:
   push:
     branches: [ "main", "master" ]
-  pull_request:
-    branches: [ "main", "master" ]
   workflow_dispatch:
 
 jobs:

--- a/app/src/main/java/com/texteditor/app/MainActivity.java
+++ b/app/src/main/java/com/texteditor/app/MainActivity.java
@@ -83,9 +83,15 @@ public class MainActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+        // setDefaultNightMode은 super.onCreate() 이전에 호출해야
+        // Activity recreate() 루프 없이 올바른 테마가 즉시 적용됨
         prefs = getSharedPreferences("settings", MODE_PRIVATE);
         loadSettings();
+        AppCompatDelegate.setDefaultNightMode(
+            isDarkMode ? AppCompatDelegate.MODE_NIGHT_YES : AppCompatDelegate.MODE_NIGHT_NO
+        );
+
+        super.onCreate(savedInstanceState);
 
         binding = ActivityMainBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
@@ -180,9 +186,6 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void applySettings() {
-        AppCompatDelegate.setDefaultNightMode(
-            isDarkMode ? AppCompatDelegate.MODE_NIGHT_YES : AppCompatDelegate.MODE_NIGHT_NO
-        );
         highlighter.setDarkMode(isDarkMode);
 
         binding.editText.setTextSize(currentFontSize);
@@ -634,9 +637,10 @@ public class MainActivity extends AppCompatActivity {
         }
         if (id == R.id.menu_dark_mode)    {
             isDarkMode = !isDarkMode;
-            item.setChecked(isDarkMode);
             saveSettings();
-            applySettings();
+            AppCompatDelegate.setDefaultNightMode(
+                isDarkMode ? AppCompatDelegate.MODE_NIGHT_YES : AppCompatDelegate.MODE_NIGHT_NO
+            );
             return true;
         }
         if (id == R.id.menu_file_type)    { showFileTypeDialog(); return true; }


### PR DESCRIPTION
## Summary

- `AppCompatDelegate.setDefaultNightMode()`를 `super.onCreate()` 이전으로 이동 — Activity recreate() 루프로 인한 즉시 종료 문제 수정
- CI 워크플로우에서 `pull_request` 트리거 제거 (push 시에만 빌드 실행)
- 테마 `NoActionBar` 변경 및 mipmap 아이콘 빌드 에러 수정

## 원인 분석

`applySettings()`에서 `setDefaultNightMode()`를 `setContentView()` 이후에 호출하면
AppCompat 기본값(`MODE_NIGHT_FOLLOW_SYSTEM`)과 달라 즉시 `recreate()`가 트리거됨.
앱이 실행되자마자 종료되는 것처럼 보이는 원인이었음.

## Test plan

- [ ] 앱 최초 실행 시 정상 화면 표시 확인
- [ ] 다크모드 토글 정상 전환 확인
- [ ] 파일 열기/저장 동작 확인
- [ ] CI 빌드가 push 시 1회만 실행되는지 확인