### PR TITLE
fix: 앱 실행 즉시 종료 문제 근본 원인 수정 - Application 레벨에서 야간 모드 초기화

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29"/>
 
     <application
+        android:name=".TextEditorApp"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/com/texteditor/app/MainActivity.java
+++ b/app/src/main/java/com/texteditor/app/MainActivity.java
@@ -83,15 +83,9 @@ public class MainActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        // setDefaultNightMode은 super.onCreate() 이전에 호출해야
-        // Activity recreate() 루프 없이 올바른 테마가 즉시 적용됨
+        super.onCreate(savedInstanceState);
         prefs = getSharedPreferences("settings", MODE_PRIVATE);
         loadSettings();
-        AppCompatDelegate.setDefaultNightMode(
-            isDarkMode ? AppCompatDelegate.MODE_NIGHT_YES : AppCompatDelegate.MODE_NIGHT_NO
-        );
-
-        super.onCreate(savedInstanceState);
 
         binding = ActivityMainBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());

--- a/app/src/main/java/com/texteditor/app/TextEditorApp.java
+++ b/app/src/main/java/com/texteditor/app/TextEditorApp.java
@@ -1,0 +1,22 @@
+package com.texteditor.app;
+
+import android.app.Application;
+import android.content.SharedPreferences;
+
+import androidx.appcompat.app.AppCompatDelegate;
+
+public class TextEditorApp extends Application {
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        // Activity가 생성되기 전에 야간 모드를 설정해야
+        // attachBaseContext2()가 올바른 모드로 컨텍스트를 래핑하여
+        // Activity recreate() 없이 앱이 바로 정상 실행됨
+        SharedPreferences prefs = getSharedPreferences("settings", MODE_PRIVATE);
+        boolean isDarkMode = prefs.getBoolean("dark_mode", false);
+        AppCompatDelegate.setDefaultNightMode(
+            isDarkMode ? AppCompatDelegate.MODE_NIGHT_YES : AppCompatDelegate.MODE_NIGHT_NO
+        );
+    }
+}


### PR DESCRIPTION
[문제 원인]
Activity의 attachBaseContext()는 onCreate()보다 먼저 호출되며, 이 시점에
AppCompatDelegateImpl.attachBaseContext2()가 시스템 야간 모드를 기준으로
컨텍스트를 래핑함. 이후 onCreate()에서 setDefaultNightMode()를 호출해도
이미 래핑된 컨텍스트와 설정값이 불일치하여 super.onCreate() 내부의
applyDayNight()가 recreate()를 호출 → 앱이 매 실행마다 재시작되는 현상 발생.

[해결 방법]
- TextEditorApp(Application) 클래스 추가: Application.onCreate()에서
  SharedPreferences를 읽어 setDefaultNightMode()를 호출함.
  Application은 Activity보다 먼저 생성되므로 attachBaseContext2()가
  올바른 모드로 컨텍스트를 래핑 → recreate() 불필요.
- AndroidManifest.xml: android:name=".TextEditorApp" 등록
- MainActivity.onCreate(): super.onCreate()를 첫 줄로 복원,
  잘못 배치된 setDefaultNightMode() 호출 제거

https://claude.ai/code/session_01Fi1akjHodLAtoGSD2RECBa